### PR TITLE
orm: Delegate ResultSet calls to QuerySet Iterator

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -1310,6 +1310,16 @@ class QuerySet implements IteratorAggregate, ArrayAccess, Serializable, Countabl
         unset($this->count);
     }
 
+    function __call($name, $args) {
+
+        if (!is_callable(array($this->getIterator(), $name)))
+            throw new OrmException('Call to undefined method QuerySet::'.$name);
+
+        return $args
+            ? call_user_func_array(array($this->getIterator(), $name), $args)
+            : call_user_func(array($this->getIterator(), $name));
+    }
+
     // IteratorAggregate interface
     function getIterator($iterator=false) {
         if (!isset($this->_iterator)) {


### PR DESCRIPTION
Allows for ability to access results without the need to call getIterator on
the QuerySet. For example - $this->members->findFirst(array(...));

This commit addresses regression issue brought about by commits 8ab4432f and
eb0ba31 -- where ResultSet processing changed based on caching mode.
